### PR TITLE
Update filter to not remove Ruler-class Servants

### DIFF
--- a/fetch_servants.js
+++ b/fetch_servants.js
@@ -43,7 +43,7 @@ async function fetchAndSaveServants() {
         // Filter out unwanted entries
         servant.type === 'normal' &&
         servant.collectionNo > 0 &&
-        !servant.id.toString().startsWith('9') &&
+        !servant.id.toString().startsWith('99') &&
         servant.bondGrowth && // Ensure bond data exists
         (servant.cost > 0 || servant.className.toLowerCase() === 'shielder')
       )

--- a/fetch_servants_jp.js
+++ b/fetch_servants_jp.js
@@ -51,7 +51,7 @@ async function fetchServants() {
                 // Filter out unwanted entries
                 servant.type === 'normal' &&
                 servant.collectionNo > 0 &&
-                !servant.id.toString().startsWith('9') &&
+                !servant.id.toString().startsWith('99') &&
                 servant.bondGrowth && // Ensure bond data exists
                 (servant.cost > 0 || servant.className.toLowerCase() === 'shielder')
             )

--- a/src/App.js
+++ b/src/App.js
@@ -259,7 +259,6 @@ function App() {
           (servant) =>
             servant.bondGrowth &&
             servant.className &&
-            !servant.collectionNo.toString().startsWith("9") &&
             !servant.id.toString().startsWith("99") &&
             !(servant.name.toLowerCase().includes("solomon") && servant.className.toLowerCase().includes("caster")) &&
             (servant.cost > 0 || servant.className.toLowerCase() === "shielder")


### PR DESCRIPTION
Per Atlas Academy's information, Ruler-class Servants begin with ID 9, and non-playable Servants begin with ID 99. Filtering on just '9' was removing the Rulers from `servants.json`.

This PR will not update the existing servant list, but the next sync will add the Ruler Servants back in.

This will fix #2 